### PR TITLE
Fix support for multiple [Export("contract")] in MEF

### DIFF
--- a/src/DependencyInjection.Tests/CompositionTests.cs
+++ b/src/DependencyInjection.Tests/CompositionTests.cs
@@ -62,6 +62,19 @@ public class CompositionTests
 
         Assert.Same(singleton, instance.Singleton);
     }
+
+    [Fact]
+    public void RegisterKeyedService()
+    {
+        var collection = new ServiceCollection();
+        collection.AddServices();
+        var services = collection.BuildServiceProvider();
+
+        var first = services.GetRequiredKeyedService<SingletonService>("foo");
+        var second = services.GetRequiredKeyedService<SingletonService>("foo");
+
+        Assert.Same(first, second);
+    }
 }
 
 public interface ICompositionSingleton { }
@@ -70,6 +83,7 @@ public interface ICompositionTransient { }
 [Shared]
 [Export]
 [Export(typeof(ICompositionSingleton))]
+[Export("foo")]
 public class SingletonService : ICompositionSingleton
 {
 }

--- a/src/DependencyInjection/IncrementalGenerator.cs
+++ b/src/DependencyInjection/IncrementalGenerator.cs
@@ -97,7 +97,7 @@ public class IncrementalGenerator : IIncrementalGenerator
                             lifetime = (int)serviceAttr.ConstructorArguments[0].Value!;
                         }
                     }
-                    else
+                    else if (IsExport(attr))
                     {
                         // In NuGet MEF, [Shared] makes exports singleton
                         if (attrs.Any(a => a.AttributeClass?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::System.Composition.SharedAttribute"))
@@ -116,11 +116,10 @@ public class IncrementalGenerator : IIncrementalGenerator
                         }
 
                         // Consider the [Export(contractName)] as a keyed service with the contract name as the key.
-                        if (attrs.FirstOrDefault(IsExport) is { } export &&
-                            export.ConstructorArguments.Length > 0 &&
-                            export.ConstructorArguments[0].Kind == TypedConstantKind.Primitive)
+                        if (attr.ConstructorArguments.Length > 0 &&
+                            attr.ConstructorArguments[0].Kind == TypedConstantKind.Primitive)
                         {
-                            key = export.ConstructorArguments[0];
+                            key = attr.ConstructorArguments[0];
                         }
                     }
 

--- a/src/DependencyInjection/Properties/launchSettings.json
+++ b/src/DependencyInjection/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Tests": {
       "commandName": "DebugRoslynComponent",
-      "targetProject": "..\\DependencyInjection.Attributed.Tests\\Attributed.Tests.csproj"
+      "targetProject": "..\\DependencyInjection.Tests\\DependencyInjection.Tests.csproj"
     },
     "Console": {
       "commandName": "DebugRoslynComponent",


### PR DESCRIPTION
When using MEF attributes, we were not considering each export attribute individually like we do for `[Service]`. We now have parity.