### PR TITLE
Detect and report inconsistencies in registration lifetimes

### DIFF
--- a/src/CodeAnalysis.Tests/ConventionAnalyzerTests.cs
+++ b/src/CodeAnalysis.Tests/ConventionAnalyzerTests.cs
@@ -3,10 +3,13 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Devlooped.Extensions.DependencyInjection;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using Xunit.Abstractions;
@@ -54,7 +57,7 @@ public class ConventionAnalyzerTests(ITestOutputHelper Output)
                     .AddPackages(ImmutableArray.Create(
                         new PackageIdentity("Microsoft.Extensions.DependencyInjection", "8.0.0")))
             },
-        }.WithPreprocessorSymbols();
+        };
 
         var expected = Verifier.Diagnostic(ConventionsAnalyzer.AssignableTypeOfRequired).WithLocation(0);
         test.ExpectedDiagnostics.Add(expected);
@@ -98,7 +101,7 @@ public class ConventionAnalyzerTests(ITestOutputHelper Output)
                     .AddPackages(ImmutableArray.Create(
                         new PackageIdentity("Microsoft.Extensions.DependencyInjection", "8.0.0")))
             },
-        }.WithPreprocessorSymbols();
+        };
 
         //var expected = Verifier.Diagnostic(ConventionsAnalyzer.AssignableTypeOfRequired).WithLocation(0);
         //test.ExpectedDiagnostics.Add(expected);
@@ -145,7 +148,7 @@ public class ConventionAnalyzerTests(ITestOutputHelper Output)
                     .AddPackages(ImmutableArray.Create(
                         new PackageIdentity("Microsoft.Extensions.DependencyInjection", "8.0.0")))
             },
-        }.WithPreprocessorSymbols();
+        };
 
         var expected = Verifier.Diagnostic(ConventionsAnalyzer.OpenGenericType).WithLocation(0);
         test.ExpectedDiagnostics.Add(expected);
@@ -153,4 +156,62 @@ public class ConventionAnalyzerTests(ITestOutputHelper Output)
         await test.RunAsync();
     }
 
+    [Fact]
+    public async Task WarnIfAmbiguousLifetime()
+    {
+        var test = new CSharpSourceGeneratorTest<IncrementalGenerator, DefaultVerifier>
+        {
+            TestBehaviors = TestBehaviors.SkipGeneratedSourcesCheck,
+            TestCode =
+            """
+            using System;
+            using Microsoft.Extensions.DependencyInjection;
+            
+            public interface IRepository { }
+            public class MyRepository : IRepository { }
+            
+            public static class Program
+            {
+                public static void Main()
+                {
+                    var services = new ServiceCollection();
+                    {|#0:services.AddServices(typeof(IRepository), ServiceLifetime.Scoped)|};
+                    {|#1:services.AddServices("Repository", ServiceLifetime.Singleton)|};
+                }
+            }
+            """,
+            TestState =
+            {
+                AnalyzerConfigFiles =
+                {
+                    ("/.editorconfig",
+                    """
+                    is_global = true
+                    build_property.AddServicesExtension = true
+                    """)
+                },
+                Sources =
+                {
+                    StaticGenerator.AddServicesExtension,
+                    StaticGenerator.ServiceAttribute,
+                    StaticGenerator.ServiceAttributeT,
+                },
+                ReferenceAssemblies = new ReferenceAssemblies(
+                    "net8.0",
+                    new PackageIdentity(
+                        "Microsoft.NETCore.App.Ref", "8.0.0"),
+                        Path.Combine("ref", "net8.0"))
+                    .AddPackages(ImmutableArray.Create(
+                        new PackageIdentity("Microsoft.Extensions.DependencyInjection", "8.0.0")))
+            },
+        };
+
+        var expected = Verifier.Diagnostic(IncrementalGenerator.AmbiguousLifetime)
+            .WithArguments("MyRepository", "Scoped, Singleton")
+            .WithLocation(0).WithLocation(1);
+
+        test.ExpectedDiagnostics.Add(expected);
+
+        await test.RunAsync();
+    }
 }

--- a/src/DependencyInjection.Tests/DependencyInjection.Tests.csproj
+++ b/src/DependencyInjection.Tests/DependencyInjection.Tests.csproj
@@ -17,6 +17,8 @@
     <PackageReference Include="System.Composition.AttributedModel" Version="8.0.0" />
     <PackageReference Include="System.Composition.Hosting" Version="8.0.0" />
     <PackageReference Include="System.Composition.TypedParts" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="6.0.0" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.1" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>
@@ -31,6 +33,11 @@
   <Import Project="..\SponsorLink\SponsorLink\buildTransitive\Devlooped.Sponsors.targets" />
   <Import Project="..\DependencyInjection\Devlooped.Extensions.DependencyInjection.targets" />
   <Import Project="..\SponsorLink\SponsorLink.Analyzer.Tests.targets" />
+
+  <ItemGroup>
+    <Analyzer Include="$(PkgMicrosoft_Bcl_HashCode)\lib\netstandard2.0\Microsoft.Bcl.HashCode.dll" />
+    <Analyzer Include="$(PkgMicrosoft_Bcl_TimeProvider)\lib\netstandard2.0\Microsoft.Bcl.TimeProvider.dll" />
+  </ItemGroup>
 
   <!-- Force immediate reporting of status, no install-time grace period -->
   <PropertyGroup>


### PR DESCRIPTION
A given type may match more than once when using convention registrations (i.e. typeof(IDisposable) and separately, by regex).

Ideally there should be no overlap for the same concrete type, as that may cause weird lifetime bugs due to the first one to register the implementation type to "win" (since we use TryAddXXX). So it should be a warning to have a case where this happens.

Fixes #115