### PR TITLE
Don't report inconsitencies if lifetimes match

### DIFF
--- a/src/DependencyInjection.Tests/GenerationTests.cs
+++ b/src/DependencyInjection.Tests/GenerationTests.cs
@@ -381,7 +381,9 @@ public class SmsNotificationService : INotificationService
 
 // Showcases that legacy generic Service<TKey> attribute still works
 [Service("email")]
+#pragma warning disable CS0618 // Type or member is obsolete
 [Service<string>("default")]
+#pragma warning restore CS0618 // Type or member is obsolete
 public class EmailNotificationService : INotificationService
 {
     public string Notify(string message) => $"[Email] {message}";


### PR DESCRIPTION
We automatically deduplicate service registrations that are exactly the same, so we don't need to report that case.