### PR TITLE
Make sure we don't attempt to analyze methods without a symbol

### DIFF
--- a/src/DependencyInjection/AddServicesAnalyzer.cs
+++ b/src/DependencyInjection/AddServicesAnalyzer.cs
@@ -59,7 +59,7 @@ public class AddServicesAnalyzer : DiagnosticAnalyzer
                     .OfType<InvocationExpressionSyntax>()
                     .Select(invocation => new { Invocation = invocation, semantic.GetSymbolInfo(invocation, semanticContext.CancellationToken).Symbol })
                     // It has to be user-provided code, not our own extensions/overloads.
-                    .Where(x => !IsDDICode(x.Invocation, semantic))
+                    .Where(x => !IsDDICode(x.Invocation, semantic) && x.Symbol != null)
                     .Select(x => new { x.Invocation, Method = (IMethodSymbol)x.Symbol! });
 
                 bool IsServiceCollectionExtension(IMethodSymbol method) => method.IsExtensionMethod &&


### PR DESCRIPTION
Since we need a resolved invocation syntax to an actual symbol in order to determine if it's the service collection method we are looking for.