### PR TITLE
Don't emit registrations with generics that don't satisfy constraints

### DIFF
--- a/src/DependencyInjection.Tests/DependencyInjection.Tests.csproj
+++ b/src/DependencyInjection.Tests/DependencyInjection.Tests.csproj
@@ -10,6 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.50.0" />
     <PackageReference Include="xunit" Version="2.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />

--- a/src/DependencyInjection.Tests/Regressions.cs
+++ b/src/DependencyInjection.Tests/Regressions.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Spectre.Console.Cli;
+
+namespace Tests.Regressions;
+
+public class Regressions
+{
+    [Fact]
+    public void CovariantRegistrationSatisfiesIntefaceConstraints()
+    {
+        var collection = new ServiceCollection();
+        collection.AddServices(typeof(ICommand));
+
+        var provider = collection.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<MyCommand>();
+
+        Assert.Equal(0, command.Execute(new CommandContext([], Mock.Of<IRemainingArguments>(), "my", null),
+            new MySetting { Base = "", Name = "" }));
+    }
+}
+
+public interface ISetting
+{
+    string Name { get; set; }
+}
+
+public class BaseSetting : CommandSettings
+{
+    [CommandArgument(0, "<BASE>")]
+    public required string Base { get; init; }
+}
+
+public class MySetting : BaseSetting, ISetting
+{
+    [CommandOption("--name")]
+    public required string Name { get; set; }
+}
+
+public class MyCommand : BaseCommand<MySetting> { }
+
+public abstract class BaseCommand<TSettings> : Command<TSettings> where TSettings : BaseSetting, ISetting
+{
+    public override int Execute(CommandContext context, TSettings settings)
+    {
+        Console.WriteLine($"Base: {settings.Base}, Name: {settings.Name}");
+        return 0;
+    }
+}

--- a/src/DependencyInjection/ConstraintsChecker.cs
+++ b/src/DependencyInjection/ConstraintsChecker.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Text;
+using Microsoft.CodeAnalysis;
+
+namespace Devlooped.Extensions.DependencyInjection;
+
+static class ConstraintsChecker
+{
+    public static bool SatisfiesConstraints(this ITypeSymbol typeArgument, ITypeParameterSymbol typeParameter)
+    {
+        // Check reference type constraint
+        if (typeParameter.HasReferenceTypeConstraint && !typeArgument.IsReferenceType)
+            return false;
+
+        // Check value type constraint
+        if (typeParameter.HasValueTypeConstraint && !typeArgument.IsValueType)
+            return false;
+
+        // Check base class and interface constraints
+        foreach (var constraint in typeParameter.ConstraintTypes)
+        {
+            if (constraint.TypeKind == TypeKind.Class)
+            {
+                if (!typeArgument.GetBaseTypes().Any(baseType => SymbolEqualityComparer.Default.Equals(baseType, constraint)))
+                    return false;
+            }
+            else if (constraint.TypeKind == TypeKind.Interface)
+            {
+                if (!typeArgument.AllInterfaces.Any(interfaceSymbol => SymbolEqualityComparer.Default.Equals(interfaceSymbol, constraint)))
+                    return false;
+            }
+        }
+
+        // Constructor constraint (optional, not typically needed here)
+        if (typeParameter.HasConstructorConstraint)
+        {
+            // Check for parameterless constructor (simplified)
+            var hasParameterlessConstructor = typeArgument.GetMembers(".ctor")
+                .OfType<IMethodSymbol>()
+                .Any(ctor => ctor.Parameters.Length == 0);
+            if (!hasParameterlessConstructor)
+                return false;
+        }
+
+        return true;
+    }
+
+    static IEnumerable<ITypeSymbol> GetBaseTypes(this ITypeSymbol typeSymbol)
+    {
+        var currentType = typeSymbol.BaseType;
+        while (currentType != null && currentType.SpecialType != SpecialType.System_Object)
+        {
+            yield return currentType;
+            currentType = currentType.BaseType;
+        }
+    }
+}


### PR DESCRIPTION
We were emitting instantiations of generic interfaces (implemented by the service) for covariant type parameters that didn't satisfy the generic type parameter constraints.