### PR TITLE
Don't generate any of the registrations during design-time

### DIFF
--- a/src/DependencyInjection/Devlooped.Extensions.DependencyInjection.targets
+++ b/src/DependencyInjection/Devlooped.Extensions.DependencyInjection.targets
@@ -14,6 +14,8 @@
   <ItemGroup>
     <CompilerVisibleProperty Include="AddServiceAttribute" />
     <CompilerVisibleProperty Include="AddServicesExtension" />
+    <!-- To quickly exit if true -->
+    <CompilerVisibleProperty Include="DesignTimeBuild" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsEditor)' != 'true'">

--- a/src/DependencyInjection/IncrementalGenerator.cs
+++ b/src/DependencyInjection/IncrementalGenerator.cs
@@ -86,10 +86,11 @@ public class IncrementalGenerator : IIncrementalGenerator
         {
             (var compilation, var options) = x;
 
-            // We won't add any registrations in this case.            
-            if (!options.GlobalOptions.TryGetValue("build_property.AddServicesExtension", out var value) ||
+            // We won't add any registrations in these cases.            
+            if (options.IsDesignTimeBuild() ||
+                !options.GlobalOptions.TryGetValue("build_property.AddServicesExtension", out var value) ||
                 !bool.TryParse(value, out var addServices) || !addServices)
-                return Enumerable.Empty<INamedTypeSymbol>();
+                return [];
 
             var visitor = new TypesVisitor(s => compilation.IsSymbolAccessible(s), c);
             compilation.GlobalNamespace.Accept(visitor);


### PR DESCRIPTION
This would otherwise slow down IDE/editor usage unnecessarily.