### PR TITLE
⬆️ Bump files with dotnet-file sync

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 # normalize by default
 * text=auto encoding=UTF-8
 *.sh text eol=lf
+*.sbn eol=lf
 
 # These are windows specific files which we may as well ensure are
 # always crlf on checkout

--- a/.netconfig
+++ b/.netconfig
@@ -31,9 +31,9 @@
 	weak
 [file ".gitattributes"]
 	url = https://github.com/devlooped/oss/blob/main/.gitattributes
-	sha = 5f92a68e302bae675b394ef343114139c075993e
+	sha = 4a9aa321c4982b83c185cf8dffed181ff84667d5
 
-	etag = 338ba6d92c8d1774363396739c2be4257bfc58026f4b0fe92cb0ae4460e1eff7
+	etag = 09cad18280ed04b67f7f87591e5481510df04d44c3403231b8af885664d8fd58
 	weak
 [file ".github/dependabot.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/dependabot.yml
@@ -213,19 +213,19 @@
 	weak
 [file "src/SponsorLink/SponsorLink.Analyzer.Tests.targets"]
 	url = https://github.com/devlooped/SponsorLink/blob/main/samples/dotnet/SponsorLink.Analyzer.Tests.targets
-	sha = 1454a8f481610a6cf33adfc6082a19421bbed43c
+	sha = 8ddf00042fa27cfce0f39a3e33e74488e2cc9bae
 
 
 
-	etag = a06c8e06228a859eb15ba9ffad88c15874048a2ee23e515029fc36a78df1349c
+	etag = 78cc938e28a2a5c3cbe1de009762ae370c49d9aa4866bf75ff8fe7a2322b9251
 	weak
 [file "src/SponsorLink/SponsorLink.Analyzer.targets"]
 	url = https://github.com/devlooped/SponsorLink/blob/main/samples/dotnet/SponsorLink.Analyzer.targets
-	sha = 1454a8f481610a6cf33adfc6082a19421bbed43c
+	sha = e8ec200934a3b3788c2e31d7022c717f5fd152fa
 
 
 
-	etag = 0b4028f3cbc6463257b741106186689bdc7d1b20af5d1d0075e81e6d4fbe8d7b
+	etag = 0c9a86982db302f74f56220ecf6842c8f7d1da1d35916d5c2d00372810056af5
 	weak
 [file "src/SponsorLink/SponsorLink/AnalyzerOptionsExtensions.cs"]
 	url = https://github.com/devlooped/SponsorLink/blob/main/samples/dotnet/SponsorLink/AnalyzerOptionsExtensions.cs
@@ -272,10 +272,10 @@
 	weak
 [file "src/SponsorLink/SponsorLink/SponsorLink.csproj"]
 	url = https://github.com/devlooped/SponsorLink/blob/main/samples/dotnet/SponsorLink/SponsorLink.csproj
-	sha = 2de6c983fd620ac8a268327c247f1ba4351ba29a
+	sha = e8ec200934a3b3788c2e31d7022c717f5fd152fa
 
 
-	etag = 0d1ba307ebf2ffa53af749afc408c738566cf1a334eb7df16dc64cb243f6233d
+	etag = 1a58baf82b1813f68610272aa6161a18a70d5c619154734039a0d48fce6d735a
 	weak
 [file "src/SponsorLink/SponsorLink/SponsorLinkAnalyzer.cs"]
 	url = https://github.com/devlooped/SponsorLink/blob/main/samples/dotnet/SponsorLink/SponsorLinkAnalyzer.cs
@@ -369,10 +369,10 @@
 	weak
 [file "src/SponsorLink/Tests/Tests.csproj"]
 	url = https://github.com/devlooped/SponsorLink/blob/main/samples/dotnet/Tests/Tests.csproj
-	sha = 2de6c983fd620ac8a268327c247f1ba4351ba29a
+	sha = e8ec200934a3b3788c2e31d7022c717f5fd152fa
 
 
-	etag = 3fc99ed4d45124df055e60a0b89aedc46286c973c05859a5cada0daa0457efbd
+	etag = eb34fc9fe25b0169f069ff692379a19c59673727d8abb6f45816012661329df5
 	weak
 [file "src/SponsorLink/Tests/keys/kzu.key"]
 	url = https://github.com/devlooped/SponsorLink/blob/main/samples/dotnet/Tests/keys/kzu.key

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 
 <!-- include https://github.com/devlooped/.github/raw/main/sponsorlinkr.md -->
 *This project uses [SponsorLink](https://github.com/devlooped#sponsorlink) to attribute sponsor status (direct, indirect or implicit).*
-*For IDE usage, sponsor status is required. IDE-only warnings will be issued after a grace period otherwise.*
+*For IDE usage (without warnings), sponsor status is required. IDE-only warnings will be issued after a grace period otherwise.*
 
 <!-- https://github.com/devlooped/.github/raw/main/sponsorlinkr.md -->
 
@@ -326,7 +326,6 @@ The versioning scheme for packages is:
 [![Jacob Foshee](https://raw.githubusercontent.com/devlooped/sponsors/main/.github/avatars/jfoshee.png "Jacob Foshee")](https://github.com/jfoshee)
 [![](https://raw.githubusercontent.com/devlooped/sponsors/main/.github/avatars/Mrxx99.png "")](https://github.com/Mrxx99)
 [![Eric Johnson](https://raw.githubusercontent.com/devlooped/sponsors/main/.github/avatars/eajhnsn1.png "Eric Johnson")](https://github.com/eajhnsn1)
-[![Ix Technologies B.V.](https://raw.githubusercontent.com/devlooped/sponsors/main/.github/avatars/IxTechnologies.png "Ix Technologies B.V.")](https://github.com/IxTechnologies)
 [![David JENNI](https://raw.githubusercontent.com/devlooped/sponsors/main/.github/avatars/davidjenni.png "David JENNI")](https://github.com/davidjenni)
 [![Jonathan ](https://raw.githubusercontent.com/devlooped/sponsors/main/.github/avatars/Jonathan-Hickey.png "Jonathan ")](https://github.com/Jonathan-Hickey)
 [![Charley Wu](https://raw.githubusercontent.com/devlooped/sponsors/main/.github/avatars/akunzai.png "Charley Wu")](https://github.com/akunzai)
@@ -341,6 +340,8 @@ The versioning scheme for packages is:
 [![Vincent Limo](https://raw.githubusercontent.com/devlooped/sponsors/main/.github/avatars/v-limo.png "Vincent Limo")](https://github.com/v-limo)
 [![Jordan S. Jones](https://raw.githubusercontent.com/devlooped/sponsors/main/.github/avatars/jordansjones.png "Jordan S. Jones")](https://github.com/jordansjones)
 [![domischell](https://raw.githubusercontent.com/devlooped/sponsors/main/.github/avatars/DominicSchell.png "domischell")](https://github.com/DominicSchell)
+[![Mauricio Scheffer](https://raw.githubusercontent.com/devlooped/sponsors/main/.github/avatars/mausch.png "Mauricio Scheffer")](https://github.com/mausch)
+[![Justin Wendlandt](https://raw.githubusercontent.com/devlooped/sponsors/main/.github/avatars/jwendl.png "Justin Wendlandt")](https://github.com/jwendl)
 
 
 <!-- sponsors.md -->

--- a/src/SponsorLink/SponsorLink.Analyzer.Tests.targets
+++ b/src/SponsorLink/SponsorLink.Analyzer.Tests.targets
@@ -7,12 +7,12 @@
 
   <ItemGroup Condition="'$(ManagePackageVersionsCentrally)' == 'true'">
     <PackageReference Include="Humanizer.Core" VersionOverride="2.14.1" PrivateAssets="all" Pack="false" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.5.0" PrivateAssets="all" Pack="false" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.9.0" PrivateAssets="all" Pack="false" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(ManagePackageVersionsCentrally)' != 'true'">
     <PackageReference Include="Humanizer.Core" Version="2.14.1" PrivateAssets="all" Pack="false" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.5.0" PrivateAssets="all" Pack="false" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.9.0" PrivateAssets="all" Pack="false" />
   </ItemGroup>
 
   <Target Name="AddSponsorLinkAnalyzerDependencies" BeforeTargets="CoreCompile" DependsOnTargets="ResolveLockFileCopyLocalFiles">

--- a/src/SponsorLink/SponsorLink.Analyzer.targets
+++ b/src/SponsorLink/SponsorLink.Analyzer.targets
@@ -84,14 +84,14 @@
   <ItemGroup Condition="'$(ManagePackageVersionsCentrally)' == 'true'">
     <PackageReference Include="Humanizer.Core" VersionOverride="2.14.1" PrivateAssets="all" Pack="$(PackMergedAssemblies)" />
     <PackageReference Include="Humanizer.Core.es" VersionOverride="2.14.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" VersionOverride="8.5.0" PrivateAssets="all" Pack="$(PackMergedAssemblies)" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" VersionOverride="8.9.0" PrivateAssets="all" Pack="$(PackMergedAssemblies)" />
     <PackageReference Include="ILRepack" Version="2.0.37" VersionOverride="all" PrivateAssets="all" Pack="false" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(ManagePackageVersionsCentrally)' != 'true'">
     <PackageReference Include="Humanizer.Core" Version="2.14.1" PrivateAssets="all" Pack="$(PackMergedAssemblies)" />
     <PackageReference Include="Humanizer.Core.es" Version="2.14.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.5.0" PrivateAssets="all" Pack="$(PackMergedAssemblies)" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.9.0" PrivateAssets="all" Pack="$(PackMergedAssemblies)" />
     <PackageReference Include="ILRepack" Version="2.0.37" PrivateAssets="all"  Pack="false" />
   </ItemGroup>
 

--- a/src/SponsorLink/SponsorLink/SponsorLink.csproj
+++ b/src/SponsorLink/SponsorLink/SponsorLink.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="NuGetizer" Version="1.2.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" Pack="false" />
     <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.5.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.9.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SponsorLink/Tests/Tests.csproj
+++ b/src/SponsorLink/Tests/Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.5.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.9.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="ThisAssembly.Resources" Version="2.0.10" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
# devlooped/oss

- Ensure lf for Scriban templates always https://github.com/devlooped/oss/commit/4a9aa32

# devlooped/SponsorLink

- Bump JWT also in samples https://github.com/devlooped/SponsorLink/commit/e8ec200
- Update SponsorLink.Analyzer.Tests.targets to match JWT version of core https://github.com/devlooped/SponsorLink/commit/8ddf000