### PR TITLE
Repurpose older [Service<T>] to allow specifying a service type

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,8 @@ public interface IMyService
 
 The `ServiceLifetime` argument is optional and defaults to [ServiceLifetime.Singleton](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.servicelifetime?#fields).
 
-> NOTE: The attribute is matched by simple name, so you can define your own attribute 
+> [!NOTE]
+> The attribute is matched by simple name, so you can define your own attribute 
 > in your own assembly. It only has to provide a constructor receiving a 
 > [ServiceLifetime](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.servicelifetime) argument, 
 > and optionally an overload receiving an `object key` for keyed services.
@@ -77,12 +78,26 @@ app.MapGet("/", (IMyService service) => service.Message);
 app.Run();
 ```
 
-> NOTE: the service is available automatically for the scoped request, because 
+> [!NOTE]
+> The service is available automatically for the scoped request, because 
 > we called the generated `AddServices` that registers the discovered services. 
 
 And that's it. The source generator will discover annotated types in the current 
 project and all its references too. Since the registration code is generated at 
 compile-time, there is no run-time reflection (or dependencies) whatsoever.
+
+If the service implements many interfaces and you want to register it only for 
+a specific one, you can specify that as the generic argument:
+
+```csharp
+[Service<IMyService>(ServiceLifetime.Scoped)]
+public class MyService : IMyService, IDisposable
+```
+
+> [!TIP]
+> If no specific interface is provided, all implemented interfaces are registered 
+> for the same service implementation (and they all resolve to the same instance, 
+> except for transient lifetime).
 
 ### Convention-based
 
@@ -156,6 +171,7 @@ right `INotificationService` will be injected, based on the key provided.
 Note you can also register the same service using multiple keys, as shown in the 
 `EmailNotificationService` above.
 
+> [!IMPORTANT]
 > Keyed services are a feature of version 8.0+ of Microsoft.Extensions.DependencyInjection
 
 ## How It Works
@@ -180,7 +196,8 @@ other two registrations just retrieve the same service (according to its defined
 lifetime). This means the instance is reused and properly registered under 
 all implemented interfaces automatically.
 
-> NOTE: you can inspect the generated code by setting `EmitCompilerGeneratedFiles=true` 
+> [!TIP]
+> You can inspect the generated code by setting `EmitCompilerGeneratedFiles=true` 
 > in your project file and browsing the `generated` subfolder under `obj`.
 
 If the service type has dependencies, they will be resolved from the service 
@@ -262,9 +279,11 @@ public class ServiceAttribute : Attribute
 }
 ```
 
-> NOTE: since the constructor arguments are only used by the source generation to 
+
+> [!TIP]
+> Since the constructor arguments are only used by the source generation to 
 > detemine the registration style (and key), but never at run-time, you don't even need 
-> to keep it around in a field or property!
+> to keep them around in a field or property!
 
 With this in place, you only need to add this package to the top-level project 
 that is adding the services to the collection!

--- a/src/DependencyInjection.Tests/GenerationTests.cs
+++ b/src/DependencyInjection.Tests/GenerationTests.cs
@@ -272,6 +272,17 @@ public class GenerationTests(ITestOutputHelper Output)
         Assert.Same(instance, services.GetRequiredService<IAsyncDisposable>());
     }
 
+    [Fact]
+    public void RegisterWithSpecificServiceType()
+    {
+        var collection = new ServiceCollection();
+        collection.AddServices();
+        var services = collection.BuildServiceProvider();
+
+        Assert.NotNull(services.GetRequiredService<ISpecificService>());
+        Assert.Null(services.GetService<INonSpecificService>());
+    }
+
     [GenerationTests.Service(ServiceLifetime.Singleton)]
     public class MyAttributedService : IAsyncDisposable
     {
@@ -380,11 +391,19 @@ public class SmsNotificationService : INotificationService
 }
 
 // Showcases that legacy generic Service<TKey> attribute still works
+// but now with new semantics enforced by an analyzer.
 [Service("email")]
-#pragma warning disable CS0618 // Type or member is obsolete
-[Service<string>("default")]
-#pragma warning restore CS0618 // Type or member is obsolete
+[Service<INotificationService>("default")]
 public class EmailNotificationService : INotificationService
 {
     public string Notify(string message) => $"[Email] {message}";
+}
+
+public interface ISpecificService;
+public interface INonSpecificService;
+
+[Service<ISpecificService>]
+public class SpecificServiceType : ISpecificService, INonSpecificService
+{
+    public void Dispose() => throw new NotImplementedException();
 }

--- a/src/DependencyInjection/AddServicesAnalyzer.cs
+++ b/src/DependencyInjection/AddServicesAnalyzer.cs
@@ -10,8 +10,7 @@ namespace Devlooped.Extensions.DependencyInjection;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public class AddServicesAnalyzer : DiagnosticAnalyzer
 {
-    public static DiagnosticDescriptor NoAddServicesCall { get; } =
-        new DiagnosticDescriptor(
+    public static DiagnosticDescriptor NoAddServicesCall { get; } = new DiagnosticDescriptor(
         "DDI001",
         "No call to IServiceCollection.AddServices found.",
         "The AddServices extension method must be invoked in order for discovered services to be properly registered.",

--- a/src/DependencyInjection/CodeAnalysisExtensions.cs
+++ b/src/DependencyInjection/CodeAnalysisExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.Diagnostics;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 static class CodeAnalysisExtensions
@@ -7,6 +7,10 @@ static class CodeAnalysisExtensions
     /// Gets whether the current build is a design-time build.
     /// </summary>
     public static bool IsDesignTimeBuild(this AnalyzerConfigOptionsProvider options) =>
+#if DEBUG
+        // Assume if we have a debugger attached to a debug build, we want to debug the generator
+        !Debugger.IsAttached &&
+#endif
         options.GlobalOptions.TryGetValue("build_property.DesignTimeBuild", out var value) &&
         bool.TryParse(value, out var isDesignTime) && isDesignTime;
 
@@ -14,6 +18,10 @@ static class CodeAnalysisExtensions
     /// Gets whether the current build is a design-time build.
     /// </summary>
     public static bool IsDesignTimeBuild(this AnalyzerConfigOptions options) =>
+#if DEBUG
+        // Assume if we have a debugger attached to a debug build, we want to debug the generator
+        !Debugger.IsAttached &&
+#endif
         options.TryGetValue("build_property.DesignTimeBuild", out var value) &&
         bool.TryParse(value, out var isDesignTime) && isDesignTime;
 }

--- a/src/DependencyInjection/ConventionsAnalyzer.cs
+++ b/src/DependencyInjection/ConventionsAnalyzer.cs
@@ -10,8 +10,7 @@ namespace Devlooped.Extensions.DependencyInjection;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public class ConventionsAnalyzer : DiagnosticAnalyzer
 {
-    public static DiagnosticDescriptor AssignableTypeOfRequired { get; } =
-        new DiagnosticDescriptor(
+    public static DiagnosticDescriptor AssignableTypeOfRequired { get; } = new DiagnosticDescriptor(
         "DDI002",
         "The convention-based registration requires a typeof() expression.",
         "When registering services by type, typeof() must be used exclusively to avoid run-time reflection.",
@@ -19,8 +18,7 @@ public class ConventionsAnalyzer : DiagnosticAnalyzer
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
-    public static DiagnosticDescriptor OpenGenericType { get; } =
-        new DiagnosticDescriptor(
+    public static DiagnosticDescriptor OpenGenericType { get; } = new DiagnosticDescriptor(
         "DDI003",
         "Open generic service implementations are not supported for convention-based registration.",
         "Only the concrete (closed) implementations of the open generic interface will be registered. Register open generic services explicitly using the built-in service collection methods.",

--- a/src/DependencyInjection/LegacyServiceAttributeAnalyzer.cs
+++ b/src/DependencyInjection/LegacyServiceAttributeAnalyzer.cs
@@ -1,0 +1,70 @@
+﻿using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Devlooped.Extensions.DependencyInjection;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public class LegacyServiceAttributeAnalyzer : DiagnosticAnalyzer
+{
+    public static DiagnosticDescriptor ServiceTypeNotKeyType { get; } = new DiagnosticDescriptor(
+        "DDI005",
+        "Generic parameter for ServiceAttribute must be the service type to register, not the service key type.",
+        "Generic parameter must not be the type of service key in use but rather the service type to register, if any.",
+        "Build",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(ServiceTypeNotKeyType);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        if (!Debugger.IsAttached)
+            context.EnableConcurrentExecution();
+
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+    }
+
+    void AnalyzeNamedType(SymbolAnalysisContext context)
+    {
+        var typeSymbol = (INamedTypeSymbol)context.Symbol;
+        foreach (var attribute in typeSymbol.GetAttributes())
+        {
+            if (attribute.AttributeClass is not { IsGenericType: true } attrClass)
+                continue;
+
+            if (attrClass.Name != "ServiceAttribute" && attrClass.Name != "Service")
+                continue;
+
+            if (attrClass.TypeArguments.Length != 1)
+                continue;
+
+            var typeArgument = attrClass.TypeArguments[0];
+            // Registering as generic object should be ok.
+            if (typeArgument.SpecialType == SpecialType.System_Object)
+                continue;
+
+            if (attribute.ConstructorArguments.Length == 0)
+                continue;
+
+            var keyArg = attribute.ConstructorArguments[0];
+
+            // If they match, this would be the legacy usage scenario we want to fix
+            if (keyArg.Type is not null &&
+                SymbolEqualityComparer.Default.Equals(keyArg.Type, typeArgument))
+            {
+                var location = attribute.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken).GetLocation()
+                    ?? typeSymbol.Locations.FirstOrDefault();
+
+                if (location is not null)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(ServiceTypeNotKeyType, location));
+                }
+            }
+        }
+    }
+}

--- a/src/DependencyInjection/Properties/launchSettings.json
+++ b/src/DependencyInjection/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "Tests": {
       "commandName": "DebugRoslynComponent",
       "targetProject": "..\\DependencyInjection.Tests\\DependencyInjection.Tests.csproj"
+    },
+    "NoAddService": {
+      "commandName": "DebugRoslynComponent",
+      "targetProject": "..\\NoAddServices\\NoAddServices.csproj"
     }
   }
 }

--- a/src/DependencyInjection/compile/ServiceAttribute.cs
+++ b/src/DependencyInjection/compile/ServiceAttribute.cs
@@ -7,6 +7,11 @@ namespace Microsoft.Extensions.DependencyInjection
     /// <summary>
     /// Configures the registration of a service in an <see cref="IServiceCollection"/>.
     /// </summary>
+    /// <remarks>
+    /// Registers the service using all interfaces implemented by the target, 
+    /// as well as <c>Func{TInterface}</c> and <c>Lazy{TInterface}</c> for each, 
+    /// so the instance can be lazily retrieved.
+    /// </remarks>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     partial class ServiceAttribute : Attribute
     {

--- a/src/DependencyInjection/compile/ServiceAttribute`1.cs
+++ b/src/DependencyInjection/compile/ServiceAttribute`1.cs
@@ -4,17 +4,26 @@ using System;
 namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
-    /// Configures the registration of a keyed service in an <see cref="IServiceCollection"/>.
-    /// Requires v8 or later of Microsoft.Extensions.DependencyInjection package.
+    /// Configures the registration of a service in an <see cref="IServiceCollection"/> using 
+    /// a specific service type.
     /// </summary>
-    /// <typeparam name="TKey">Type of service key.</typeparam>
+    /// <remarks>
+    /// Registers the service using the specific service interface, 
+    /// as well as <c>Func&lt;TService&gt;</c> and <c>Lazy&lt;TService&gt;</c>, 
+    /// so the instance can be lazily retrieved.
+    /// </remarks>
+    /// <typeparam name="TService">Type of service to register.</typeparam>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    [Obsolete("Use ServiceAttribute(object key, ServiceLifetime lifetime) instead.")]
-    partial class ServiceAttribute<TKey> : Attribute
+    partial class ServiceAttribute<TService> : Attribute
     {
         /// <summary>
         /// Annotates the service with the lifetime.
         /// </summary>
-        public ServiceAttribute(TKey key, ServiceLifetime lifetime = ServiceLifetime.Singleton) { }
+        public ServiceAttribute(ServiceLifetime lifetime = ServiceLifetime.Singleton) { }
+
+        /// <summary>
+        /// Annotates the service with the given key and lifetime.
+        /// </summary>
+        public ServiceAttribute(object key, ServiceLifetime lifetime = ServiceLifetime.Singleton) { }
     }
 }


### PR DESCRIPTION
We add an analyzer that will flag the previous usage as an error (requiring the removal of the T or setting it to the actual service to register). This should prevent bumps and rebuilds without notice.

Since the attributes don't have run-time impact but are rather purely compile-time, bumping but not building (i.e. via a transitive dependency, say or direct copying), would not cause runtime failures because the registrations in the previously compile assembly would remain as they were.

This unlocks a very useful scenario to trim down the amount of registered interfaces.

Fixes #281