### PR TITLE
Bump non-Roslyn dependencies

### DIFF
--- a/src/Attributed/Attributed.msbuildproj
+++ b/src/Attributed/Attributed.msbuildproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Build.NoTargets/3.5.0" TreatAsLocalProperty="Version">
+﻿<Project Sdk="Microsoft.Build.NoTargets/3.7.134" TreatAsLocalProperty="Version">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <PackageId>Devlooped.Extensions.DependencyInjection.Attributed</PackageId>
@@ -6,7 +6,7 @@
     <Version>2.2.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NuGetizer" Version="1.2.4" />
-    <PackageReference Include="Devlooped.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="NuGetizer" Version="1.4.9" />
+    <PackageReference Include="Devlooped.Extensions.DependencyInjection" Version="2.3.1" />
   </ItemGroup>
 </Project>

--- a/src/CodeAnalysis.Tests/CodeAnalysis.Tests.csproj
+++ b/src/CodeAnalysis.Tests/CodeAnalysis.Tests.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
-    <PackageReference Include="System.Formats.Asn1" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="System.Formats.Asn1" Version="10.0.9" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />

--- a/src/DependencyInjection.CodeAnalysis/DependencyInjection.CodeAnalysis.csproj
+++ b/src/DependencyInjection.CodeAnalysis/DependencyInjection.CodeAnalysis.csproj
@@ -13,11 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGetizer" Version="1.4.6" />
+    <PackageReference Include="NuGetizer" Version="1.4.9" />
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="6.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" Pack="false" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
-    <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="PolySharp" Version="1.16.0" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly.Resources" Version="2.1.2" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/DependencyInjection.CodeFixes/DependencyInjection.CodeFixes.csproj
+++ b/src/DependencyInjection.CodeFixes/DependencyInjection.CodeFixes.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGetizer" Version="1.4.6" />
+    <PackageReference Include="NuGetizer" Version="1.4.9" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" Pack="false" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.2.0" Pack="false" />
   </ItemGroup>

--- a/src/DependencyInjection.Tests/DependencyInjection.Tests.csproj
+++ b/src/DependencyInjection.Tests/DependencyInjection.Tests.csproj
@@ -11,16 +11,16 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Spectre.Console.Cli" Version="0.53.1" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
-    <PackageReference Include="System.ComponentModel.Composition" Version="10.0.1" />
-    <PackageReference Include="System.Composition.AttributedModel" Version="10.0.1" />
-    <PackageReference Include="System.Composition.Hosting" Version="10.0.1" />
-    <PackageReference Include="System.Composition.TypedParts" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="10.0.9" />
+    <PackageReference Include="System.Composition.AttributedModel" Version="10.0.9" />
+    <PackageReference Include="System.Composition.Hosting" Version="10.0.9" />
+    <PackageReference Include="System.Composition.TypedParts" Version="10.0.9" />
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="6.0.0" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="10.0.1" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="10.0.9" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DependencyInjection.Tests/Regressions.cs
+++ b/src/DependencyInjection.Tests/Regressions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Spectre.Console.Cli;
@@ -9,7 +10,7 @@ namespace Tests.Regressions;
 public class Regressions
 {
     [Fact]
-    public void CovariantRegistrationSatisfiesIntefaceConstraints()
+    public async Task CovariantRegistrationSatisfiesIntefaceConstraints()
     {
         var collection = new ServiceCollection();
         collection.AddServices(typeof(ICommand));
@@ -18,7 +19,7 @@ public class Regressions
 
         var command = provider.GetRequiredService<MyCommand>();
 
-        Assert.Equal(0, command.Execute(new CommandContext([], Mock.Of<IRemainingArguments>(), "my", null),
+        Assert.Equal(0, await ((ICommand)command).ExecuteAsync(new CommandContext([], Mock.Of<IRemainingArguments>(), "my", null),
             new MySetting { Base = "", Name = "" }, default));
     }
 }
@@ -44,7 +45,7 @@ public class MyCommand : BaseCommand<MySetting> { }
 
 public abstract class BaseCommand<TSettings> : Command<TSettings> where TSettings : BaseSetting, ISetting
 {
-    public override int Execute(CommandContext context, TSettings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, TSettings settings, CancellationToken cancellationToken)
     {
         Console.WriteLine($"Base: {settings.Base}, Name: {settings.Name}");
         return 0;

--- a/src/NoAddServices/NoAddServices.csproj
+++ b/src/NoAddServices/NoAddServices.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Package/DependencyInjection.Package.msbuildproj
+++ b/src/Package/DependencyInjection.Package.msbuildproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Build.NoTargets/3.5.0" TreatAsLocalProperty="Version">
+﻿<Project Sdk="Microsoft.Build.NoTargets/3.7.134" TreatAsLocalProperty="Version">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Devlooped.Extensions.DependencyInjection</PackageId>
@@ -12,7 +12,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NuGetizer" Version="1.2.4" />
+    <PackageReference Include="NuGetizer" Version="1.4.9" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DependencyInjection.CodeFixes\DependencyInjection.CodeFixes.csproj" />

--- a/src/Samples/ConsoleApp/ConsoleApp.csproj
+++ b/src/Samples/ConsoleApp/ConsoleApp.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageReference Include="Devlooped.Extensions.DependencyInjection" Version="42.*" />
   </ItemGroup>
 

--- a/src/Samples/Library1/Library1.csproj
+++ b/src/Samples/Library1/Library1.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Devlooped.Extensions.DependencyInjection" Version="42.*" />
-    <PackageReference Include="PolySharp" PrivateAssets="all" Version="1.14.1" />
-    <PackageReference Include="Merq" Version="2.0.0" />
+    <PackageReference Include="PolySharp" PrivateAssets="all" Version="1.16.0" />
+    <PackageReference Include="Merq" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Samples/Library2/Library2.csproj
+++ b/src/Samples/Library2/Library2.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PolySharp" PrivateAssets="all" Version="1.14.1" />
-    <PackageReference Include="Merq" Version="2.0.0" />
+    <PackageReference Include="PolySharp" PrivateAssets="all" Version="1.16.0" />
+    <PackageReference Include="Merq" Version="3.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bumps non-Roslyn package and MSBuild SDK dependencies to their latest stable versions discovered from NuGet.org, while leaving all `Microsoft.CodeAnalysis.*` references unchanged.

Also updates the Spectre CLI regression test to use the public async `ICommand` execution path required by `Spectre.Console.Cli` 0.55.0, whose typed `Command<TSettings>.Execute` override is now protected.

## Bumped

- `Microsoft.Build.NoTargets`: `3.5.0` -> `3.7.134`
- `NuGetizer`: `1.2.4`/`1.4.6` -> `1.4.9`
- `Devlooped.Extensions.DependencyInjection`: `2.2.0` -> `2.3.1` in the attributed compatibility package
- `Microsoft.Extensions.DependencyInjection`: `7.0.0`/`10.0.1` -> `10.0.9`
- `Microsoft.Extensions.DependencyInjection.Abstractions`: `10.0.1` -> `10.0.9`
- `System.Formats.Asn1`: `10.0.1` -> `10.0.9`
- `System.ComponentModel.Composition`: `10.0.1` -> `10.0.9`
- `System.Composition.AttributedModel`: `10.0.1` -> `10.0.9`
- `System.Composition.Hosting`: `10.0.1` -> `10.0.9`
- `System.Composition.TypedParts`: `10.0.1` -> `10.0.9`
- `Microsoft.Bcl.TimeProvider`: `10.0.1` -> `10.0.9`
- `Spectre.Console.Cli`: `0.53.1` -> `0.55.0`
- `PolySharp`: `1.14.1`/`1.15.0` -> `1.16.0`
- `Merq`: `2.0.0` -> `3.0.0`

## Not changed

- All `Microsoft.CodeAnalysis.*` PackageReferences remain unchanged as requested.
- Floating `Devlooped.Extensions.DependencyInjection` sample references remain at `42.*` for the repo's local dogfood package flow.

## Validation

Using temporary SDKs installed under `/tmp` because the agent image did not include `dotnet`:

- `dotnet test src/CodeAnalysis.Tests/CodeAnalysis.Tests.csproj` - passed, with existing NU1608 warnings from the unchanged Roslyn testing package set
- `dotnet test src/DependencyInjection.Tests/DependencyInjection.Tests.csproj` - passed with 0 warnings
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://devlooped.slack.com/archives/D0BDT1Y5065/p1782685892464679?thread_ts=1782685892.464679&cid=D0BDT1Y5065)

<div><a href="https://cursor.com/agents/bc-0fd77fd7-1b86-53de-853b-9cb23f4601f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd77fd7-1b86-53de-853b-9cb23f4601f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

